### PR TITLE
ci(github): publish artifacts on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Java CI
 on:
   pull_request: { }
   push: { }
+  release:
+    types: [ published ]
 jobs:
   build:
     name: Build, Test, and Verify


### PR DESCRIPTION
The action was only triggered by a push event (for the tag), but in
order to build the specific release version, it needs to be triggered by
the release published event.