### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
     <maven.version>3.0</maven.version>
 
     <nexus.snapshot.repository>
-      https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/
+      https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
     </nexus.snapshot.repository>
-    <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/
+    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
     </nexus.release.repository>
 
     <version.junit>5.8.2</version.junit>
@@ -174,7 +174,7 @@
     <repository>
       <id>zeebe</id>
       <name>Zeebe Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -186,7 +186,7 @@
     <repository>
       <id>zeebe-snapshots</id>
       <name>Zeebe Snapshot Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
As announced in #engineering slack channel, we created a new Artifactory domain since the nexus one used now is a proxy URL and will be removed in the future.

Related to INFRA-3114